### PR TITLE
Added --user on pip install

### DIFF
--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -4,7 +4,7 @@ sudo apt upgrade -y
 
 sudo apt install -y jq g++-11 git python3 python3-pip cppcheck clang-tidy-13 clang-tidy ccache moreutils
 
-pip install conan ninja cmake
+pip install --user conan ninja cmake
 
 sudo snap install code --classic
 


### PR DESCRIPTION
On Ubuntu's system, the `--user` is irrelevant (since that's the default behavior), but on other Linux systems using pip on a non virtual environment and without that flag will try to install the packages system-wide and will fail because of the lack of sudo permissions. Adding the `--user` makes this a more general script that might be used for other Linux systems.